### PR TITLE
Fix angle calc for radial tiers

### DIFF
--- a/main.js
+++ b/main.js
@@ -125,11 +125,12 @@ function drawArcText(svg, config, cx, cy) {
 function drawRadialTier(svg, config, tierIndex, cx, cy, rotationOffset) {
   const count = config.divisionWeights.length;
   const full = wheelConfig.globalDivisionCount;
+  const weightSum = config.divisionWeights.reduce((a, b) => a + b, 0);
   let currentAngle = (rotationOffset * 360) / full;
 
   for (let i = 0; i < count; i++) {
     const weight = config.divisionWeights[i];
-    const angle = (weight / full) * 360;
+    const angle = (weight / weightSum) * 360;
     const startAngle = currentAngle;
     const endAngle = currentAngle + angle;
     currentAngle = endAngle;


### PR DESCRIPTION
## Summary
- use the sum of `divisionWeights` when computing radial slice angles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f2c0851e08322bf8720ad7deb1710