### PR TITLE
Switch to named dataset imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ labelList: Local list of strings or generated (e.g. T5 modifiers)
 
 labelListSource: Used in T6 to dynamically switch datasets
 
-availableSources: ["quotes", "emotions", "tone", "behavior", "thriveCounterQuote"]
+availableSources: ["quotes", "emotion", "tone", "behavior", "thriveCounter"]
 
 Data is modular — content can be swapped by toggling source
 

--- a/config.js
+++ b/config.js
@@ -229,7 +229,7 @@ const tiers = [
     rotationLocked: false,
     divisionWeights: Array(132).fill(1),
     labelListSource: "quotes",
-    availableSources: ["quotes", "emotions", "tone", "behavior", "thriveCounterQuote"],
+    availableSources: ["quotes", "emotion", "tone", "behavior", "thriveCounter"],
     labelStyle: {
       type: "radial",
       fontSize: 5,
@@ -277,5 +277,5 @@ export const wheelConfig = {
   renderOptions,
   tiers,
   overlays,
-  availableSources: ["quotes", "emotions", "tone", "behavior", "thriveCounterQuote"]
+  availableSources: ["quotes", "emotion", "tone", "behavior", "thriveCounter"]
 };

--- a/index.html
+++ b/index.html
@@ -21,10 +21,10 @@
   <!-- T6 Label Set Controls -->
   <div id="t6-controls">
     <button data-t6="quotes">Quotes</button>
-    <button data-t6="emotions">Emotions</button>
+    <button data-t6="emotion">Emotions</button>
     <button data-t6="tone">Tone</button>
     <button data-t6="behavior">Behavior</button>
-    <button data-t6="thriveCounterQuote">Thrive</button>
+    <button data-t6="thriveCounter">Thrive</button>
   </div>
 
   <br />

--- a/wheelData.js
+++ b/wheelData.js
@@ -1,10 +1,10 @@
 // === wheelData.js — BIM Masterwheel Data ===
 
-import quotes from './quotes.js';
-import emotions from './emotion.js';
-import tone from './tone.js';
-import behavior from './behavior.js';
-import thriveCounterQuote from './thriveCounter.js';
+import { quotes } from './quotes.js';
+import { emotion } from './emotion.js';
+import { tone } from './tone.js';
+import { behaviorDescriptions as behavior } from './behavior.js';
+import { thriveCounter } from './thriveCounter.js';
 
 export const wheelData = {
   // T0–T2: Single labels
@@ -51,8 +51,8 @@ export const wheelData = {
 
   // T6 variants
   quotes,
-  emotions,
+  emotion,
   tone,
   behavior,
-  thriveCounterQuote
+  thriveCounter
 };


### PR DESCRIPTION
## Summary
- use named imports in `wheelData.js`
- rename dataset keys to `quotes`, `emotion`, `tone`, `behavior`, and `thriveCounter`
- update config and README with new dataset names
- update dataset selector IDs in HTML

## Testing
- `node -e "import('./wheelData.js').then(m=>console.log('ok', Object.keys(m)))" --experimental-modules --es-module-specifier-resolution=node`

------
https://chatgpt.com/codex/tasks/task_e_684f2bf8870083228c5209387a093c50