### PR TITLE
Fix T3 weights and clarify slice logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,14 @@ inherit: Uses prior tier’s color at same index (T5, T6)
 
 divisionWeights[]: Every tier from T3–T6 uses manual arrays
 
-T3 = 10 weighted instincts (summing to 132)
+T3 = 10 weighted instincts (weights sum to 132)
 
 T4 = 33 behaviors × 4 divisions = 132
 
 T5/T6 = 132 divisions
+
+Slice angles are determined per tier by (weight / globalDivisionCount) × 360°, so higher
+weights produce wider segments.
 
 No calculations are auto-derived — all index math is hard-defined
 

--- a/config.js
+++ b/config.js
@@ -104,7 +104,7 @@ const tiers = [
     innerRadius: 60,
     outerRadius: 120,
     rotationLocked: false,
-    divisionWeights: [5, 3, 3, 3, 3, 3, 3, 3, 3, 4],
+    divisionWeights: [20, 12, 12, 12, 12, 12, 12, 12, 12, 16],
     labelList: [
       "Fight", "Fight ↔ Flight", "Flight", "Flight ↔ Freeze",
       "Freeze", "Freeze ↔ Flop", "Flop", "Flop ↔ Friend",


### PR DESCRIPTION
## Summary
- adjust Tier3 weights so they total 132 divisions
- document the correct weight total and how slice angles are derived

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f2e0b2b388322ae1e12a47e3b8d80