### PR TITLE
Fix arc text path length

### DIFF
--- a/main.js
+++ b/main.js
@@ -92,7 +92,9 @@ function drawArcText(svg, config, cx, cy) {
 
   const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
   const startAngle = 0;
-  const endAngle = 360;
+  // Use an end angle slightly less than 360° so the arc has a non-zero length
+  // when start and end points coincide.
+  const endAngle = startAngle + 359.9;
   const largeArc = endAngle - startAngle <= 180 ? 0 : 1;
 
   const start = polarToCartesian(cx, cy, radius, endAngle);


### PR DESCRIPTION
## Summary
- prevent arc text path from degenerating by keeping end angle below 360 degrees

## Testing
- `node -e "require('./main.js')"` *(fails: SyntaxError: The requested module './behavior.js' does not provide an export named 'default')*

------
https://chatgpt.com/codex/tasks/task_e_684f25d2e1988322944dbc045b57a0a9