### PR TITLE
Fix dataset switching for T6 labels

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,7 +16,11 @@ function renderWheel() {
   svg.appendChild(defs);
 
   for (let i = 0; i < wheelConfig.tiers.length; i++) {
-    drawTier(svg, wheelConfig.tiers[i], i, centerX, centerY, currentRotation, defs);
+    const tier = wheelConfig.tiers[i];
+    if (tier.labelListSource) {
+      tier.labelList = wheelData[tier.labelListSource];
+    }
+    drawTier(svg, tier, i, centerX, centerY, currentRotation, defs);
   }
 }
 


### PR DESCRIPTION
## Summary
- update `renderWheel` to load label lists from wheelData
- keep dataset buttons working by refreshing the wheel after source changes

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_684f3bb1022c83228ec18078abbcba65